### PR TITLE
Move API base URLs to Cloudflare environment variables

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,2 +1,0 @@
-export const API_APP_STAPE_IO = "https://api.app.stape.io/api/v2";
-export const API_APP_EU_STAPE_IO = "https://api.app.eu.stape.io/api/v2";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { McpAgent } from "agents/mcp";
 import { Hono } from "hono";
-import { API_APP_EU_STAPE_IO, API_APP_STAPE_IO } from "./constants/api";
 import { McpAgentPropsModel } from "./models/McpAgentModel";
 import { tools } from "./tools";
 import { getPackageVersion } from "./utils";
@@ -39,7 +38,7 @@ app.mount(
     const regionHeader = req.headers.get("X-Stape-Region");
     const isEU = regionHeader?.toUpperCase() === "EU";
 
-    const apiBaseUrl = isEU ? API_APP_EU_STAPE_IO : API_APP_STAPE_IO;
+    const apiBaseUrl = isEU ? env.API_APP_EU_URL : env.API_APP_GLOBAL_URL;
 
     ctx.props = {
       apiKey,
@@ -63,7 +62,7 @@ app.mount(
     const regionHeader = req.headers.get("X-Stape-Region");
     const isEU = regionHeader?.toUpperCase() === "EU";
 
-    const apiBaseUrl = isEU ? API_APP_EU_STAPE_IO : API_APP_STAPE_IO;
+    const apiBaseUrl = isEU ? env.API_APP_EU_URL : env.API_APP_GLOBAL_URL;
 
     ctx.props = {
       apiKey,

--- a/src/tools/resource/billingResourceActions.ts
+++ b/src/tools/resource/billingResourceActions.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { API_APP_STAPE_IO } from "../../constants/api";
 import { McpAgentToolParamsModel } from "../../models/McpAgentModel";
 import { OptionModel } from "../../models/OptionModel";
 import { createErrorResponse, HttpClient, log } from "../../utils";
@@ -32,7 +31,7 @@ export const billingResourceActions = (
       log(`Running tool: stape_billing_resource - type: ${type}`);
 
       try {
-        const httpClient = new HttpClient(API_APP_STAPE_IO, props.apiKey);
+        const httpClient = new HttpClient(props.apiBaseUrl, props.apiKey);
         const headers = userWorkspaceIdentifier
           ? { "X-WORKSPACE": userWorkspaceIdentifier }
           : undefined;

--- a/src/tools/resource/containerResourceActions.ts
+++ b/src/tools/resource/containerResourceActions.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { API_APP_STAPE_IO } from "../../constants/api";
 import { McpAgentToolParamsModel } from "../../models/McpAgentModel";
 import { OptionModel } from "../../models/OptionModel";
 import { createErrorResponse, HttpClient, log } from "../../utils";
@@ -37,7 +36,7 @@ export const containerResourceActions = (
       log(`Running tool: stape_container_resource - type: ${type}`);
 
       try {
-        const httpClient = new HttpClient(API_APP_STAPE_IO, props.apiKey);
+        const httpClient = new HttpClient(props.apiBaseUrl, props.apiKey);
         const headers = userWorkspaceIdentifier
           ? { "X-WORKSPACE": userWorkspaceIdentifier }
           : undefined;

--- a/src/tools/resource/domainsResourceActions.ts
+++ b/src/tools/resource/domainsResourceActions.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { API_APP_STAPE_IO } from "../../constants/api";
 import { McpAgentToolParamsModel } from "../../models/McpAgentModel";
 import { OptionModel } from "../../models/OptionModel";
 import { createErrorResponse, HttpClient, log } from "../../utils";
@@ -32,7 +31,7 @@ export const domainsResourceActions = (
       log(`Running tool: stape_domains_resource - type: ${type}`);
 
       try {
-        const httpClient = new HttpClient(API_APP_STAPE_IO, props.apiKey);
+        const httpClient = new HttpClient(props.apiBaseUrl, props.apiKey);
         const headers = userWorkspaceIdentifier
           ? { "X-WORKSPACE": userWorkspaceIdentifier }
           : undefined;

--- a/src/tools/resource/gatewayResourceActions.ts
+++ b/src/tools/resource/gatewayResourceActions.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { API_APP_STAPE_IO } from "../../constants/api";
 import { McpAgentToolParamsModel } from "../../models/McpAgentModel";
 import { OptionModel } from "../../models/OptionModel";
 import { createErrorResponse, HttpClient, log } from "../../utils";
@@ -45,7 +44,7 @@ export const gatewayResourceActions = (
       log(`Running tool: stape_gateway_resource - type: ${type}`);
 
       try {
-        const httpClient = new HttpClient(API_APP_STAPE_IO, props.apiKey);
+        const httpClient = new HttpClient(props.apiBaseUrl, props.apiKey);
         const headers = userWorkspaceIdentifier
           ? { "X-WORKSPACE": userWorkspaceIdentifier }
           : undefined;

--- a/src/tools/resource/logsResourceActions.ts
+++ b/src/tools/resource/logsResourceActions.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { API_APP_STAPE_IO } from "../../constants/api";
 import { McpAgentToolParamsModel } from "../../models/McpAgentModel";
 import { OptionModel } from "../../models/OptionModel";
 import { createErrorResponse, HttpClient, log } from "../../utils";
@@ -32,7 +31,7 @@ export const logsResourceActions = (
       log(`Running tool: stape_logs_resource - type: ${type}`);
 
       try {
-        const httpClient = new HttpClient(API_APP_STAPE_IO, props.apiKey);
+        const httpClient = new HttpClient(props.apiBaseUrl, props.apiKey);
         const headers = userWorkspaceIdentifier
           ? { "X-WORKSPACE": userWorkspaceIdentifier }
           : undefined;

--- a/src/tools/resource/monitoringResourceActions.ts
+++ b/src/tools/resource/monitoringResourceActions.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { API_APP_STAPE_IO } from "../../constants/api";
 import { McpAgentToolParamsModel } from "../../models/McpAgentModel";
 import { OptionModel } from "../../models/OptionModel";
 import { createErrorResponse, HttpClient, log } from "../../utils";
@@ -34,7 +33,7 @@ export const monitoringResourceActions = (
       log(`Running tool: stape_monitoring_resource - type: ${type}`);
 
       try {
-        const httpClient = new HttpClient(API_APP_STAPE_IO, props.apiKey);
+        const httpClient = new HttpClient(props.apiBaseUrl, props.apiKey);
         const headers = userWorkspaceIdentifier
           ? { "X-WORKSPACE": userWorkspaceIdentifier }
           : undefined;

--- a/src/tools/resource/partnerResourceActions.ts
+++ b/src/tools/resource/partnerResourceActions.ts
@@ -1,7 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { API_APP_STAPE_IO } from "../../constants/api";
 import { McpAgentToolParamsModel } from "../../models/McpAgentModel";
 import { OptionModel } from "../../models/OptionModel";
 import { createErrorResponse, HttpClient, log } from "../../utils";
@@ -38,7 +37,7 @@ export const partnerResourceActions = (
       log(`Running tool: stape_partner_resource - type: ${type}`);
 
       try {
-        const httpClient = new HttpClient(API_APP_STAPE_IO, props.apiKey);
+        const httpClient = new HttpClient(props.apiBaseUrl, props.apiKey);
         const headers = userWorkspaceIdentifier
           ? { "X-WORKSPACE": userWorkspaceIdentifier }
           : undefined;

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,6 +8,8 @@ declare namespace Cloudflare {
 }
 
 interface Env extends Cloudflare.Env {
+  API_APP_GLOBAL_URL: string;
+  API_APP_EU_URL: string;
 }
 
 // Begin runtime types

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,6 +29,10 @@
   "observability": {
     "enabled": true
   },
+  "vars": {
+    "API_APP_GLOBAL_URL": "https://api.app.stape.io/api/v2",
+    "API_APP_EU_URL": "https://api.app.eu.stape.io/api/v2"
+  },
   "routes": [
     {
       "pattern": "mcp.stape.ai",


### PR DESCRIPTION
- Replace hardcoded API_APP_STAPE_IO / API_APP_EU_STAPE_IO constants with Cloudflare env vars API_APP_GLOBAL_URL and API_APP_EU_URL
- Add prod values to wrangler.jsonc vars (global + EU)
- Update Env interface in worker-configuration.d.ts
- Update src/index.ts to read from env instead of constants
- Fix resource action files to use props.apiBaseUrl (already region-aware) instead of importing the hardcoded constant directly
- Remove src/constants/api.ts